### PR TITLE
Fixed bug, sequence empty error

### DIFF
--- a/MiraAPI/Utilities/Extensions.cs
+++ b/MiraAPI/Utilities/Extensions.cs
@@ -197,6 +197,6 @@ public static class Extensions
             .Where(playerInfo => !playerInfo.Data.Disconnected && playerInfo.PlayerId != playerControl.PlayerId && !playerInfo.Data.IsDead &&
                                  (includeImpostors || !playerInfo.Data.Role.IsImpostor));
 
-        return filteredPlayers.First();
+        return filteredPlayers.FirstOrDefault();
     }
 }


### PR DESCRIPTION
On a button that had a get target function and was using PlayerControl.GetClosestPlayer(), it spammed null errors. This fixes it with a one line fix.