### PR TITLE
Local Settings

### DIFF
--- a/MiraAPI.Example/ExampleLocalSettings.cs
+++ b/MiraAPI.Example/ExampleLocalSettings.cs
@@ -1,0 +1,44 @@
+﻿using BepInEx.Configuration;
+using MiraAPI.LocalSettings;
+using Reactor.Utilities;
+using UnityEngine;
+
+namespace MiraAPI.Example;
+
+public static class ExampleLocalSettings
+{
+    public static ModSettingsTab ExampleTab;
+    
+    public static ConfigEntry<bool> ExampleBoolEntry;
+    public static ConfigEntry<bool> ExampleColoredEntry;
+    public static ConfigEntry<int> ExampleIntEntry;
+    public static ConfigEntry<float> ExampleFloatEntry;
+    public static ConfigEntry<ExampleSettingEnum> ExampleEnumEntry;
+    
+    public enum ExampleSettingEnum
+    {
+        Cheeseburger,
+        Fries,
+        Pizza,
+        ChickenNuggets,
+    }
+
+    public static void Example()
+    {
+        var plugin = PluginSingleton<ExamplePlugin>.Instance;
+        var config = plugin.Config;
+        
+        ExampleBoolEntry = config.Bind("General", "Example Bool Setting", true, "You can toggle this on and off.");
+        ExampleColoredEntry = config.Bind("General", "Example Colored Setting", false);
+        ExampleIntEntry = config.Bind("General", "Example Int Setting", 3, "You can switch between numbers.");
+        ExampleFloatEntry = config.Bind("Misc", "Example Float Setting", 50f);
+        ExampleEnumEntry = config.Bind("Misc", "Example Enum Setting", ExampleSettingEnum.Cheeseburger, "This one has values from an enum :o");
+
+        ExampleTab = LocalSettingsManager.CreateSettingsTab(plugin);
+        ExampleTab.BindEntry(ExampleBoolEntry);
+        ExampleTab.BindBoolEntry(ExampleColoredEntry, onColor: Color.green, offColor: Color.red);
+        ExampleTab.BindEntry(ExampleIntEntry);
+        ExampleTab.BindEntry(ExampleFloatEntry);
+        ExampleTab.BindEnumEntry(ExampleEnumEntry, enumType: typeof(ExampleSettingEnum), customNames: ["Cheeseburger", "Fries", "Pizza", "Chicken Nuggets"]);
+    }
+}

--- a/MiraAPI.Example/ExamplePlugin.cs
+++ b/MiraAPI.Example/ExamplePlugin.cs
@@ -22,5 +22,7 @@ public partial class ExamplePlugin : BasePlugin, IMiraPlugin
     public override void Load()
     {
         Harmony.PatchAll();
+
+        ExampleLocalSettings.Example();
     }
 }

--- a/MiraAPI/LocalSettings/ConfigEntrySettings.cs
+++ b/MiraAPI/LocalSettings/ConfigEntrySettings.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Linq;
+using BepInEx.Configuration;
+using BepInEx.Unity.IL2CPP;
+using UnityEngine;
+
+namespace MiraAPI.LocalSettings;
+
+public interface IConfigEntrySetting
+{
+    string Name { get; }
+    string Description { get; }
+    BasePlugin Plugin { get; }
+    ConfigEntryBase BaseEntry { get; }
+}
+
+/// <summary>
+/// Base class for Config Entries Settings
+/// </summary>
+public abstract class ConfigEntrySetting<T>(
+    BasePlugin plugin,
+    ConfigEntry<T> entry,
+    string name = null,
+    string description = null) : IConfigEntrySetting
+{
+    public string Name { get; } = name ?? entry.Definition.Key;
+    public string Description { get; } = description ?? entry.Description.Description;
+    
+    public BasePlugin Plugin { get; } = plugin;
+    public ConfigEntry<T> Entry { get; } = entry;
+    public ConfigEntryBase BaseEntry { get; } = entry as ConfigEntryBase;
+}
+
+/// <summary>
+/// Class for Config Entry Bool Settings
+/// </summary>
+public class ConfigEntryBoolSetting(
+    BasePlugin plugin,
+    ConfigEntry<bool> entry,
+    string name = null,
+    string description = null,
+    Color? onColor = null,
+    Color? offColor = null)
+    : ConfigEntrySetting<bool>(plugin, entry, name, description)
+{
+    public readonly Color OnColor = onColor ?? Palette.AcceptedGreen;
+    public readonly Color OffColor = offColor ?? Color.white;
+}
+
+/// <summary>
+/// Class for Config Entry Float Settings
+/// </summary>
+public class ConfigEntryFloatSetting(
+    BasePlugin plugin,
+    ConfigEntry<float> entry,
+    string name = null,
+    Color? sliderColor = null,
+    FloatRange sliderRange = null,
+    bool roundValue = true)
+    : ConfigEntrySetting<float>(plugin, entry, name, "")
+{
+    public readonly Color SliderColor = sliderColor ?? Palette.AcceptedGreen;
+    public readonly FloatRange SliderRange = sliderRange ?? new(0, 100);
+    public readonly bool RoundValue = roundValue;
+}
+
+/// <summary>
+/// Class for Config Entry Int Settings
+/// </summary>
+public class ConfigEntryIntSetting(
+    BasePlugin plugin,
+    ConfigEntry<int> entry,
+    string name = null,
+    string description = null,
+    Color? color = null,
+    IntRange range = null)
+    : ConfigEntrySetting<int>(plugin, entry, name, description)
+{
+    public readonly Color Color = color ?? Palette.AcceptedGreen;
+    public readonly IntRange Range = range ?? new(0, 3);
+}
+
+/// <summary>
+/// Class for Config Entry Enum Settings
+/// </summary>
+public class ConfigEntryEnumSetting<T>(
+    BasePlugin plugin,
+    ConfigEntry<T> entry,
+    Type enumType,
+    string name = null,
+    string description = null,
+    Color? color = null,
+    string[] customNames = null)
+    : ConfigEntrySetting<T>(plugin, entry, name, description) where T : Enum
+{
+    public readonly Color Color = color ?? Palette.AcceptedGreen;
+    public readonly Type EnumType = enumType;
+    public int ValueIndex = Enum.GetNames(enumType).ToList().IndexOf(entry.Value.ToString());
+    public readonly string[] EnumNames = customNames ?? Enum.GetNames(enumType);
+}

--- a/MiraAPI/LocalSettings/LocalSettingsManager.cs
+++ b/MiraAPI/LocalSettings/LocalSettingsManager.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using BepInEx.Unity.IL2CPP;
+using Reactor.Utilities;
+using UnityEngine;
+
+namespace MiraAPI.LocalSettings;
+
+/// <summary>
+/// Manages the setting tabs
+/// </summary>
+public static class LocalSettingsManager
+{
+    internal static readonly List<ModSettingsTab> AllTabs = new();
+
+    /// <summary>
+    /// Creates a settings tab for your mod
+    /// </summary>
+    /// <param name="plugin">Your mod's plugin.</param>
+    /// <param name="title">Title of your tab. This will show when the button is hovered.</param>
+    /// <param name="shortTitle">Short version of title. Showed when button is not hovered. Replaced by Icon if it's set.</param>
+    /// <param name="tabColor">Color of the tab button.</param>
+    /// <param name="tabHoverColor">Color of the tab button when it's hovered.</param>
+    /// <param name="icon">Icon of your tab button.</param>
+    /// <returns>The created tab.</returns>
+    public static ModSettingsTab CreateSettingsTab(BasePlugin plugin, string title = null, string shortTitle = null, Color? tabColor = null, Color? tabHoverColor = null, Sprite icon = null)
+    {
+        ModSettingsTab settings = new(plugin, title, shortTitle, tabColor, tabHoverColor, icon);
+        AllTabs.Add(settings);
+        Logger<MiraApiPlugin>.Info($"Settings tab created for {plugin}");
+        return settings;
+    }
+}

--- a/MiraAPI/LocalSettings/ModSettingsTab.cs
+++ b/MiraAPI/LocalSettings/ModSettingsTab.cs
@@ -67,7 +67,7 @@ public class ModSettingsTab
                     // Make it generic using the enum type
                     MethodInfo genericMethod = method.MakeGenericMethod(entry.SettingType);
                     
-                    setting = genericMethod.Invoke(this, new object[] { entry, entry.SettingType, name, description }) as IConfigEntrySetting;
+                    setting = genericMethod.Invoke(this, new object[] { entry, entry.SettingType, name, description, null, null }) as IConfigEntrySetting;
                     break;
                 }
                 Logger<MiraApiPlugin>.Error($"Unsupported type of {entry.Definition} from {Plugin}: {entry.SettingType.Name}");

--- a/MiraAPI/LocalSettings/ModSettingsTab.cs
+++ b/MiraAPI/LocalSettings/ModSettingsTab.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using BepInEx;
+using BepInEx.Configuration;
+using BepInEx.Unity.IL2CPP;
+using Reactor.Utilities;
+using UnityEngine;
+
+namespace MiraAPI.LocalSettings;
+
+/// <summary>
+/// Class for storing each mod's settings
+/// </summary>
+public class ModSettingsTab
+{
+    public readonly BasePlugin Plugin;
+    public readonly List<IConfigEntrySetting> ConfigEntries = new();
+
+    public readonly string Title;
+    public readonly string ShortTitle;
+    public readonly Color TabColor;
+    public readonly Color TabHoverColor;
+    public readonly Sprite Icon;
+    
+    public ModSettingsTab(BasePlugin plugin, string title = null, string shortTitle = null, Color? tabColor = null, Color? tabHoverColor = null, Sprite icon = null)
+    {
+        Plugin = plugin;
+
+        var metadata = MetadataHelper.GetMetadata(plugin);
+        Title = title ?? metadata.Name;
+        ShortTitle = shortTitle ?? ShortParseName(Title);
+        TabColor = tabColor ?? Color.white;
+        TabHoverColor = tabHoverColor ?? Palette.AcceptedGreen;
+        Icon = icon;
+    }
+    
+    /// <summary>
+    /// Creates a setting for your ConfigEntry.
+    /// Use specific bind methods if you need to override more properties
+    /// </summary>
+    /// <param name="entry">The entry you want to bind.</param>
+    /// <param name="name">Overriden name of your setting.</param>
+    /// <param name="description">Overriden description of your setting.</param>
+    /// <returns>The created setting. Null if entry type is not supported or something else went wrong.</returns>
+    public IConfigEntrySetting? BindEntry(ConfigEntryBase entry, string name = null, string description = null)
+    {
+        IConfigEntrySetting setting = null;
+        switch (entry)
+        {
+            case ConfigEntry<bool> boolEntry:
+                setting = BindBoolEntry(boolEntry, name, description);
+                break;
+            case ConfigEntry<float> floatEntry:
+                setting = BindFloatEntry(floatEntry, name, description);
+                break;
+            case ConfigEntry<int> intEntry:
+                setting = BindIntEntry(intEntry, name, description);
+                break;
+            default:
+                // If none of these types match, check if it's an enum
+                if (entry.SettingType.IsEnum)
+                {
+                    MethodInfo method = GetType().GetMethod(nameof(BindEnumEntry));
+
+                    // Make it generic using the enum type
+                    MethodInfo genericMethod = method.MakeGenericMethod(entry.SettingType);
+                    
+                    setting = genericMethod.Invoke(this, new object[] { entry, entry.SettingType, name, description }) as IConfigEntrySetting;
+                    break;
+                }
+                Logger<MiraApiPlugin>.Error($"Unsupported type of {entry.Definition} from {Plugin}: {entry.SettingType.Name}");
+                break;
+        }
+        
+        return setting;
+    }
+
+    public ConfigEntryBoolSetting BindBoolEntry(ConfigEntry<bool> entry, string name = null, string description = null,
+        Color? onColor = null, Color? offColor = null)
+    {
+        ConfigEntryBoolSetting setting = new(Plugin, entry, name, description, onColor, offColor);
+        ConfigEntries.Add(setting);
+        Logger<MiraApiPlugin>.Info($"{setting.GetType().Name} created for {entry.Definition} from {Plugin}");
+        return setting;
+    }
+
+    public ConfigEntryFloatSetting BindFloatEntry(ConfigEntry<float> entry, string name = null, string description = null, Color? color = null, FloatRange sliderRange = null)
+    {
+        ConfigEntryFloatSetting setting = new(Plugin, entry, name, color, sliderRange);
+        ConfigEntries.Add(setting);
+        Logger<MiraApiPlugin>.Info($"{setting.GetType().Name} created for {entry.Definition} from {Plugin}");
+        return setting;
+    }
+    
+    public ConfigEntryIntSetting BindIntEntry(ConfigEntry<int> entry, string name = null, string description = null, Color? color = null, IntRange range = null)
+    {
+        ConfigEntryIntSetting setting = new(Plugin, entry, name, description, color, range);
+        ConfigEntries.Add(setting);
+        Logger<MiraApiPlugin>.Info($"{setting.GetType().Name} created for {entry.Definition} from {Plugin}");
+        return setting;
+    }
+    
+    public ConfigEntryEnumSetting<T> BindEnumEntry<T>(ConfigEntry<T> entry, Type enumType, string name = null, string description = null, Color? color = null, string[] customNames = null) where T : Enum
+    {
+        ConfigEntryEnumSetting<T> setting = new(Plugin, entry, enumType, name, description, color, customNames);
+        ConfigEntries.Add(setting);
+        Logger<MiraApiPlugin>.Info($"{setting.GetType().Name} created for {entry.Definition} from {Plugin}");
+        return setting;
+    }
+    
+    private static string ShortParseName(string name)
+    {
+        var words = name.Split(' ');
+        string fullString = "";
+        words.ToList().ForEach(x => fullString += x[0]);
+        return fullString;
+    }
+}

--- a/MiraAPI/Patches/LocalSettings/OptionsMenuPatches.cs
+++ b/MiraAPI/Patches/LocalSettings/OptionsMenuPatches.cs
@@ -309,7 +309,7 @@ public static class OptionsMenuPatches
         else
             button.transform.localPosition = new Vector3(order == 1 ? -1.35f : 1.28f, 1.85f - offset);
 
-        tmp.text = $"{setting.Name}: {setting.Entry.Value}";
+        tmp.text = $"{setting.Name}: <b>{setting.Entry.Value}</b>";
         button.name = setting.Name;
         button.OnClick = new UnityEngine.UI.Button.ButtonClickedEvent();
         rollover.OverColor = setting.Color;
@@ -322,7 +322,7 @@ public static class OptionsMenuPatches
                 value = setting.Range.min;
 
             setting.Entry.Value = value;
-            tmp.text = $"{setting.Name}: {setting.Entry.Value}";
+            tmp.text = $"{setting.Name}: <b>{setting.Entry.Value}</b>";
         }));
         button.OnMouseOver.AddListener((UnityAction)(() =>
         {
@@ -331,7 +331,7 @@ public static class OptionsMenuPatches
         }));
         button.OnMouseOut.AddListener((UnityAction)(() =>
         {
-            tmp.text = $"{setting.Name}: {setting.Entry.Value}";
+            tmp.text = $"{setting.Name}: <b>{setting.Entry.Value}</b>";
         }));
 
         order++;
@@ -359,7 +359,7 @@ public static class OptionsMenuPatches
         else
             button.transform.localPosition = new Vector3(order == 1 ? -1.35f : 1.28f, 1.85f - offset);
 
-        tmp.text = $"{setting.Name}: {setting.EnumNames[setting.ValueIndex]}";
+        tmp.text = $"{setting.Name}: <b>{setting.EnumNames[setting.ValueIndex]}</b>";
         button.name = setting.Name;
         button.OnClick = new UnityEngine.UI.Button.ButtonClickedEvent();
         rollover.OverColor = setting.Color;
@@ -373,7 +373,7 @@ public static class OptionsMenuPatches
 
             setting.ValueIndex = value;
             setting.Entry.BoxedValue = setting.ValueIndex;
-            tmp.text = $"{setting.Name}: {setting.EnumNames[setting.ValueIndex]}";
+            tmp.text = $"{setting.Name}: <b>{setting.EnumNames[setting.ValueIndex]}</b>";
         }));
         button.OnMouseOver.AddListener((UnityAction)(() =>
         {
@@ -382,7 +382,7 @@ public static class OptionsMenuPatches
         }));
         button.OnMouseOut.AddListener((UnityAction)(() =>
         {
-            tmp.text = $"{setting.Name}: {setting.EnumNames[setting.ValueIndex]}";
+            tmp.text = $"{setting.Name}: <b>{setting.EnumNames[setting.ValueIndex]}</b>";
         }));
 
         order++;

--- a/MiraAPI/Patches/LocalSettings/OptionsMenuPatches.cs
+++ b/MiraAPI/Patches/LocalSettings/OptionsMenuPatches.cs
@@ -22,6 +22,13 @@ public static class OptionsMenuPatches
     [HarmonyPatch(nameof(OptionsMenuBehaviour.Start))]
     public static void StartPostfix(OptionsMenuBehaviour __instance)
     {
+        // Fix for tabs not being clickable in the main menu
+        if (!AmongUsClient.Instance.IsInGame)
+        {
+            __instance.Background.GetComponent<BoxCollider2D>().enabled = false;
+            __instance.transform.FindChild("Tint").SetLocalZ(5.6f);
+        }
+        
         float yOffset = 0;
         var i = 0;
         foreach (var settings in LocalSettingsManager.AllTabs)
@@ -32,6 +39,7 @@ public static class OptionsMenuPatches
             tabButton.transform.localPosition = new Vector3(2.4f, 2.1f - yOffset, 5.5f);
             tabButton.transform.localScale = new Vector3(1.25f, 1.25f, 1);
             tabButton.Button.color = settings.TabColor;
+            tabs.Remove(settings);
             tabs.Add(settings, tabButton);
 
             var text = tabButton.transform.FindChild("Text_TMP").GetComponent<TextMeshPro>();

--- a/MiraAPI/Patches/LocalSettings/OptionsMenuPatches.cs
+++ b/MiraAPI/Patches/LocalSettings/OptionsMenuPatches.cs
@@ -1,0 +1,398 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using HarmonyLib;
+using MiraAPI.LocalSettings;
+using Reactor.Localization.Utilities;
+using Reactor.Utilities.Extensions;
+using TMPro;
+using UnityEngine;
+using UnityEngine.Events;
+
+namespace MiraAPI.Patches.LocalSettings;
+
+[HarmonyPatch(typeof(OptionsMenuBehaviour))]
+public static class OptionsMenuPatches
+{
+    private static Dictionary<ModSettingsTab, TabGroup> tabs = [];
+    
+    /// <summary>
+    /// Creates the tabs and their content
+    /// </summary>
+    [HarmonyPostfix]
+    [HarmonyPatch(nameof(OptionsMenuBehaviour.Start))]
+    public static void StartPostfix(OptionsMenuBehaviour __instance)
+    {
+        float yOffset = 0;
+        var i = 0;
+        foreach (var settings in LocalSettingsManager.AllTabs)
+        {
+            // Tab button and it's appearance
+            var tabButton = GameObject.Instantiate(__instance.Tabs[0], __instance.transform);
+            tabButton.name = $"{settings.Title} Button";
+            tabButton.transform.localPosition = new Vector3(2.4f, 2.1f - yOffset, 5.5f);
+            tabButton.transform.localScale = new Vector3(1.25f, 1.25f, 1);
+            tabButton.Button.color = settings.TabColor;
+            tabs.Add(settings, tabButton);
+
+            var text = tabButton.transform.FindChild("Text_TMP").GetComponent<TextMeshPro>();
+            text.GetComponent<TextTranslatorTMP>().Destroy(); // i hate text translators
+            text.transform.localPosition = new Vector3(0.078f, 0, 0);
+            text.transform.localScale = new Vector3(0.9f, 0.9f);
+            text.alignment = TextAlignmentOptions.Right;
+            text.text = $"<b>{settings.ShortTitle}</b>";
+            
+            var button = tabButton.GetComponent<PassiveButton>();
+            var rollover = tabButton.Rollover;
+            rollover.OverColor = settings.TabHoverColor;
+            rollover.OutColor = settings.TabColor;
+            
+            var sprite = new GameObject("sprite").AddComponent<SpriteRenderer>();
+            sprite.gameObject.layer = 5; // ui layer
+            sprite.transform.SetParent(tabButton.transform);
+            sprite.transform.localPosition = new Vector3(0.5f, 0, -2);
+            sprite.transform.localScale = new Vector3(0.5f, 0.5f, 1);
+            sprite.sprite = settings.Icon;
+            
+            text.gameObject.SetActive(settings.Icon == null);   // Hide the text and show the sprite if there's an icon
+            sprite.gameObject.SetActive(settings.Icon != null);
+
+            // The actual tab object
+            var tab = GameObject.Instantiate(__instance.transform.FindChild("GeneralTab"), __instance.transform);
+            tab.name = $"{settings.Title} Tab";
+            tab.transform.DestroyChildren();
+            tab.gameObject.SetActive(false);
+            tabButton.Content = tab.gameObject;
+            
+            var generalLabel = __instance.transform.FindChild("GeneralTab").FindChild("ControlGroup").FindChild("ControlText_TMP").gameObject; // Wacky way to get objects we'll be using
+            var generalToggle = __instance.transform.FindChild("GeneralTab").FindChild("ChatGroup").FindChild("CensorChatButton").gameObject;
+            var sfxSlider = __instance.transform.FindChild("GeneralTab").FindChild("SoundGroup").FindChild("SFXSlider").gameObject;
+            
+            Dictionary<string, List<IConfigEntrySetting>> entriesByGroup = new();
+            foreach (var entry in settings.ConfigEntries) // Group the settings by their section
+            {   
+                string group = entry.BaseEntry.Definition.Section;
+                if (!entriesByGroup.ContainsKey(group))
+                    entriesByGroup.Add(group, []);
+                
+                entriesByGroup[group].Add(entry);
+            }
+            
+            float contentOffset = 0;
+            foreach (var pair in entriesByGroup) // Create the settings for each section
+            {
+                CreateLabel(generalLabel, tab.transform, pair.Key, ref contentOffset); // Section label
+                var contentOrder = 1;
+                var contentIndex = 1;
+
+                foreach (var setting in pair.Value)
+                {
+                    switch (setting)
+                    {
+                        case ConfigEntryBoolSetting boolSetting:
+                            var toggle = CreateToggle(generalToggle, tab.transform, boolSetting, ref contentOffset, ref contentOrder, contentIndex == pair.Value.Count);
+                            contentIndex++;
+                            break;
+                        case ConfigEntryFloatSetting floatSetting:
+                            var slider = CreateSlider(sfxSlider, tab.transform, floatSetting, ref contentOffset, ref contentOrder);
+                            contentIndex++;
+                            break;
+                        case ConfigEntryIntSetting intSetting:
+                            var intButton = CreateIntSetting(generalToggle, tab.transform, intSetting, ref contentOffset, ref contentOrder, contentIndex == pair.Value.Count);
+                            contentIndex++;
+                            break;
+                        default:
+                            if (setting.GetType().IsGenericType &&
+                                setting.GetType().GetGenericTypeDefinition() == typeof(ConfigEntryEnumSetting<>))
+                            {
+                                dynamic enumSetting = setting;
+                                var enumButton = CreateEnumSetting(generalToggle, tab.transform, enumSetting, ref contentOffset, ref contentOrder, contentIndex == pair.Value.Count) as PassiveButton;
+                                contentIndex++;
+                            }
+                            break;
+                    }
+                }
+            }
+
+            int tabIndex = i; // Local copies of the tab variables so we can use them in the lambdas
+            float tabOffset = yOffset;
+            
+            button.OnClick.AddListener((UnityAction)(() =>
+            {
+                __instance.OpenTabGroup(tabIndex + 10);
+            }));
+            button.OnMouseOver.AddListener((UnityAction)(() =>
+            {
+                tabButton.transform.localPosition = new Vector3(3.55f, 2.1f - tabOffset, 5.5f);
+
+                sprite.gameObject.SetActive(false);
+                text.gameObject.SetActive(true);
+                text.transform.localPosition = new Vector3(0.045f, 0, 0);
+                text.maxVisibleCharacters = 9999;
+                text.text = settings.Title;
+            }));
+            button.OnMouseOut.AddListener((UnityAction)(() =>
+            {
+                tabButton.transform.localPosition = new Vector3(2.4f, 2.1f - tabOffset, 5.5f);
+
+                if (settings.Icon != null)
+                    text.gameObject.SetActive(false);
+                sprite.gameObject.SetActive(true);
+                text.transform.localPosition = new Vector3(0.1f, 0, 0);
+                text.maxVisibleCharacters = 4;
+                text.text = $"<b>{settings.ShortTitle}</b>";
+            }));
+
+            yOffset += 0.6f;
+            i++;
+        }
+    }
+
+    /// <summary>
+    /// Modifies how opening tabs is handled for the custom ones to work
+    /// </summary>
+    [HarmonyPrefix]
+    [HarmonyPatch(nameof(OptionsMenuBehaviour.OpenTabGroup))]
+    public static bool OpenTabGroupPrefix(OptionsMenuBehaviour __instance, ref int index)
+    {
+        __instance.Tabs.ToList().ForEach(x => x.Close()); // Close all vanilla tabs
+        tabs.ToList().ForEach(CustomClose); // Close all mod tabs
+        
+        if (index >= 10) // Tabs with index 10 and above are the mod settings tabs
+        {
+            CustomOpen(tabs.ToList()[index - 10]);
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Makes the custom tabs close when opening the options menu
+    /// </summary>
+    [HarmonyPostfix]
+    [HarmonyPatch(nameof(OptionsMenuBehaviour.Open))]
+    public static void OpenPostfix(OptionsMenuBehaviour __instance)
+    {
+        tabs.ToList().ForEach(CustomClose);
+    }
+
+    private static void CustomOpen(KeyValuePair<ModSettingsTab, TabGroup> pair)
+    {
+        // For some reason this method kept throwing null reference errors randomly so...
+        if (pair.Value.Button)
+            pair.Value.Button.color = pair.Key.TabHoverColor;
+        
+        if (pair.Value.Rollover)
+            pair.Value.Rollover.OutColor = pair.Key.TabHoverColor;
+        
+        if (pair.Value.Content)
+            pair.Value.Content.SetActive(true);
+    }
+    private static void CustomClose(KeyValuePair<ModSettingsTab, TabGroup> pair)
+    {
+        // The same here
+        if (pair.Value.Button)
+            pair.Value.Button.color = pair.Key.TabColor;
+        
+        if (pair.Value.Rollover)
+            pair.Value.Rollover.OutColor = pair.Key.TabColor;
+        
+        if (pair.Value.Content)
+            pair.Value.Content.SetActive(false);
+    }
+
+    public static TextMeshPro CreateLabel(GameObject template, Transform parent, string text, ref float offset)
+    {
+        var label = GameObject.Instantiate(template, parent);
+        label.transform.localPosition = new Vector3(0, 1.85f - offset);
+        label.GetComponent<TextTranslatorTMP>().Destroy();
+        label.name = text;
+
+        var tmp = label.GetComponent<TextMeshPro>();
+        tmp.text = $"<b>{text}</b>";
+        tmp.alignment = TextAlignmentOptions.Center;
+
+        offset += 0.5f;
+        return tmp;
+    }
+
+    public static ToggleButtonBehaviour CreateToggle(GameObject template, Transform parent, ConfigEntryBoolSetting setting, ref float offset, ref int order, bool last)
+    {
+        var toggle = GameObject.Instantiate(template, parent).GetComponent<ToggleButtonBehaviour>();
+        var tmp = toggle.transform.FindChild("Text_TMP").GetComponent<TextMeshPro>();
+        var passiveButton = toggle.GetComponent<PassiveButton>();
+        var rollover = toggle.GetComponent<ButtonRolloverHandler>();
+        toggle.gameObject.SetActive(true);
+
+        if (last && order == 1)
+            toggle.transform.localPosition = new Vector3(0, 1.85f - offset);
+        else
+            toggle.transform.localPosition = new Vector3(order == 1 ? -1.35f : 1.28f, 1.85f - offset);
+
+        toggle.BaseText = CustomStringName.CreateAndRegister(setting.Name);
+        toggle.UpdateText((bool)setting.Entry.BoxedValue);
+        toggle.name = setting.Name;
+        toggle.Background.color = setting.Entry.Value ? setting.OnColor : setting.OffColor;
+        passiveButton.OnClick = new UnityEngine.UI.Button.ButtonClickedEvent();
+        rollover.OverColor = setting.OnColor;
+
+        passiveButton.OnClick.AddListener((UnityAction)(() =>
+        {
+            setting.Entry.Value = !setting.Entry.Value;
+            toggle.UpdateText(setting.Entry.Value);
+            toggle.Background.color = setting.Entry.Value ? setting.OnColor : setting.OffColor;
+        }));
+        passiveButton.OnMouseOver.AddListener((UnityAction)(() =>
+        {
+            if (!setting.Description.IsNullOrWhiteSpace())
+                tmp.text = setting.Description;
+        }));
+        passiveButton.OnMouseOut.AddListener((UnityAction)(() =>
+        {
+            toggle.UpdateText(setting.Entry.Value);
+            toggle.Background.color = setting.Entry.Value ? setting.OnColor : setting.OffColor;
+        }));
+
+        order++;
+        if (order > 2 && !last)
+        {
+            offset += 0.5f;
+            order = 1;
+        }
+        if (last)
+            offset += 0.6f;
+        return toggle;
+    }
+    
+    public static SlideBar CreateSlider(GameObject template, Transform parent, ConfigEntryFloatSetting setting, ref float offset, ref int order)
+    {
+        var slider = GameObject.Instantiate(template, parent).GetComponent<SlideBar>();
+        var rollover = slider.GetComponent<ButtonRolloverHandler>();
+        slider.Title = slider.transform.FindChild("Text_TMP").GetComponent<TextMeshPro>(); // Why the hell slider has a title property that is not even assigned???
+        slider.Title.GetComponent<TextTranslatorTMP>().Destroy();
+        slider.gameObject.SetActive(true);
+        
+        if (order == 2)
+            offset += 0.5f;
+        slider.transform.localPosition = new Vector3(-2.12f, 1.85f - offset);
+        slider.name = setting.Name;
+        slider.Range = new FloatRange(-1.5f, 1.5f);
+        slider.SetValue(Mathf.InverseLerp(setting.SliderRange.min, setting.SliderRange.max, setting.Entry.Value));
+        rollover.OverColor = setting.SliderColor;
+        slider.Title.text = $"{setting.Name}: <b>{setting.Entry.Value}</b>";
+        
+        slider.OnValueChange.AddListener((UnityAction)(() =>
+        {
+            setting.Entry.Value = setting.RoundValue
+                ? Mathf.Round(Mathf.Lerp(setting.SliderRange.min, setting.SliderRange.max, slider.Value))
+                : Mathf.Lerp(setting.SliderRange.min, setting.SliderRange.max, slider.Value);
+            
+            slider.Title.text = $"{setting.Name}: <b>{setting.Entry.Value}</b>";
+        }));
+
+        order = 1;
+        offset += 0.5f;
+        return slider;
+    }
+    
+    public static PassiveButton CreateIntSetting(GameObject template, Transform parent, ConfigEntryIntSetting setting, ref float offset, ref int order, bool last)
+    {
+        var button = GameObject.Instantiate(template, parent).GetComponent<PassiveButton>();
+        var tmp = button.transform.FindChild("Text_TMP").GetComponent<TextMeshPro>();
+        var rollover = button.GetComponent<ButtonRolloverHandler>();
+        button.GetComponent<ToggleButtonBehaviour>().Destroy();
+        tmp.GetComponent<TextTranslatorTMP>().Destroy();
+        button.gameObject.SetActive(true);
+
+        if (last && order == 1)
+            button.transform.localPosition = new Vector3(0, 1.85f - offset);
+        else
+            button.transform.localPosition = new Vector3(order == 1 ? -1.35f : 1.28f, 1.85f - offset);
+
+        tmp.text = $"{setting.Name}: {setting.Entry.Value}";
+        button.name = setting.Name;
+        button.OnClick = new UnityEngine.UI.Button.ButtonClickedEvent();
+        rollover.OverColor = setting.Color;
+
+        button.OnClick.AddListener((UnityAction)(() =>
+        {
+            int value = setting.Entry.Value;
+            value++;
+            if (value > setting.Range.max)
+                value = setting.Range.min;
+
+            setting.Entry.Value = value;
+            tmp.text = $"{setting.Name}: {setting.Entry.Value}";
+        }));
+        button.OnMouseOver.AddListener((UnityAction)(() =>
+        {
+            if (!setting.Description.IsNullOrWhiteSpace())
+                tmp.text = setting.Description;
+        }));
+        button.OnMouseOut.AddListener((UnityAction)(() =>
+        {
+            tmp.text = $"{setting.Name}: {setting.Entry.Value}";
+        }));
+
+        order++;
+        if (order > 2 && !last)
+        {
+            offset += 0.5f;
+            order = 1;
+        }
+        if (last)
+            offset += 0.6f;
+        return button;
+    }
+
+    public static PassiveButton CreateEnumSetting<T>(GameObject template, Transform parent, ConfigEntryEnumSetting<T> setting, ref float offset, ref int order, bool last) where T : System.Enum
+    {
+        var button = GameObject.Instantiate(template, parent).GetComponent<PassiveButton>();
+        var tmp = button.transform.FindChild("Text_TMP").GetComponent<TextMeshPro>();
+        var rollover = button.GetComponent<ButtonRolloverHandler>();
+        button.GetComponent<ToggleButtonBehaviour>().Destroy();
+        tmp.GetComponent<TextTranslatorTMP>().Destroy();
+        button.gameObject.SetActive(true);
+
+        if (last && order == 1)
+            button.transform.localPosition = new Vector3(0, 1.85f - offset);
+        else
+            button.transform.localPosition = new Vector3(order == 1 ? -1.35f : 1.28f, 1.85f - offset);
+
+        tmp.text = $"{setting.Name}: {setting.EnumNames[setting.ValueIndex]}";
+        button.name = setting.Name;
+        button.OnClick = new UnityEngine.UI.Button.ButtonClickedEvent();
+        rollover.OverColor = setting.Color;
+
+        button.OnClick.AddListener((UnityAction)(() =>
+        {
+            int value = setting.ValueIndex;
+            value++;
+            if (value > setting.EnumNames.Length-1)
+                value = 0;
+
+            setting.ValueIndex = value;
+            setting.Entry.BoxedValue = setting.ValueIndex;
+            tmp.text = $"{setting.Name}: {setting.EnumNames[setting.ValueIndex]}";
+        }));
+        button.OnMouseOver.AddListener((UnityAction)(() =>
+        {
+            if (!setting.Description.IsNullOrWhiteSpace())
+                tmp.text = setting.Description;
+        }));
+        button.OnMouseOut.AddListener((UnityAction)(() =>
+        {
+            tmp.text = $"{setting.Name}: {setting.EnumNames[setting.ValueIndex]}";
+        }));
+
+        order++;
+        if (order > 2 && !last)
+        {
+            offset += 0.5f;
+            order = 1;
+        }
+        if (last)
+            offset += 0.6f;
+        return button;
+    }
+}

--- a/MiraAPI/Patches/LocalSettings/ToggleBehaviourPatch.cs
+++ b/MiraAPI/Patches/LocalSettings/ToggleBehaviourPatch.cs
@@ -1,0 +1,17 @@
+﻿using HarmonyLib;
+
+namespace MiraAPI.Patches.LocalSettings;
+
+[HarmonyPatch(typeof(ToggleButtonBehaviour))]
+public static class ToggleBehaviourPatch
+{
+    /// <summary>
+    /// Makes the ToggleButtonBehaviour On/Off text bolded because it looks good.
+    /// </summary>
+    [HarmonyPostfix]
+    [HarmonyPatch(nameof(ToggleButtonBehaviour.ResetText))]
+    public static void ResetTextPrefix(ToggleButtonBehaviour __instance)
+    {
+        __instance.Text.text = $"{DestroyableSingleton<TranslationController>.Instance.GetString(__instance.BaseText)}: <b>{DestroyableSingleton<TranslationController>.Instance.GetString(__instance.onState ? StringNames.SettingsOn : StringNames.SettingsOff)}</b>";
+    }
+}

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A thorough, but simple, Among Us modding API and utility library that covers:
 
 Mira API strives to be simple and easy to use, while also using as many base game elements as possible. The result is a less intrusive, better modding API that covers general use cases.
 
-**Join the [Discord](https://discord.gg/all-of-us-launchpad-794950428756410429) for support and to stay updated on the latest releases**
+**Join the [Discord](https://discord.gg/TQeQdCCcx8) for support and to stay updated on the latest releases**
 
 # Usage
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![](https://dcbadge.limes.pink/api/server/TQeQdCCcx8)](https://discord.gg/TQeQdCCcx8)
+[![](https://dcbadge.limes.pink/api/server/FYYqJU2bvp)](https://discord.gg/FYYqJU2bvp)
 
 # Mira API
 
@@ -14,7 +14,7 @@ A thorough, but simple, Among Us modding API and utility library that covers:
 
 Mira API strives to be simple and easy to use, while also using as many base game elements as possible. The result is a less intrusive, better modding API that covers general use cases.
 
-**Join the [Discord](https://discord.gg/TQeQdCCcx8) for support and to stay updated on the latest releases**
+**Join the [Discord](https://discord.gg/FYYqJU2bvp) for support and to stay updated on the latest releases**
 
 # Usage
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![](https://dcbadge.limes.pink/api/server/all-of-us-launchpad-794950428756410429)](https://discord.gg/all-of-us-launchpad-794950428756410429)
+[![](https://dcbadge.limes.pink/api/server/TQeQdCCcx8)](https://discord.gg/TQeQdCCcx8)
 
 # Mira API
 


### PR DESCRIPTION
## What did i add?
A local settings implementation that allows users to bind BepInEx config entries to settings.
![image](https://github.com/user-attachments/assets/0fcf9ac5-7a84-4e62-a3c9-752b301bbc9a)

## How does it work?
First you need to create a `ModSettingsTab`. The best way would be to create a variable for it in the plugin class
It supports multiple tabs from one plugin
```csharp
ModSettingsTab modTab = LocalSettingsManager.CreateSettingsTab(plugin);
```
![image](https://github.com/user-attachments/assets/dd2ec9cc-eda2-41aa-ad2c-6bf279f9f6e9)

Then you can bind config entries with:
```csharp
modTab.BindEntry(YourConfigEntry);
```
`BindEntry()` method automatically binds any supported type of entry. You can bind **bool**, **int**, **float** and **enum** entries.
By default, it grabs the name and description from the entry itself, but you can set a different one with the arguments.

To modify things specific to one type, use the corresponding to type bind method:
```csharp
modTab.BindBoolEntry(BoolConfigEntry, onColor: Color.green, offColor: Color.red) // a bool one

modTab.BindEnumEntry( // an enum one
ExampleEnumEntry,
enumType: typeof(ExampleSettingEnum),
customNames: ["Cheeseburger", "Fries", "Pizza", "Chicken Nuggets"]
); 
```

## Things that might break
The amount of settings you can add is limited because after binding lots of setting they go out of the screen, so the tab would need a scroller. This issue also exists in the tabs but you would need like 10 different mods, each one having their tabs for it to fill out so i don't think it would be an issue.
From what i've tested, everything else seems to be fine