### PR TITLE
Allow modifiers to have freeplay colors

### DIFF
--- a/MiraAPI/Modifiers/BaseModifier.cs
+++ b/MiraAPI/Modifiers/BaseModifier.cs
@@ -65,6 +65,11 @@ public abstract class BaseModifier : IOptionable
     public virtual bool ShowInFreeplay => false;
 
     /// <summary>
+    /// Gets a value indicating the color that should be used for the modifier within freeplay
+    /// </summary>
+    public virtual Color FreeplayFileColor => Color.gray;
+
+    /// <summary>
     /// Gets a value indicating whether the modifier is unique. If true, the player can only have one instance of this modifier.
     /// </summary>
     public virtual bool Unique => true;

--- a/MiraAPI/Patches/Freeplay/TaskAddButtonPatches.cs
+++ b/MiraAPI/Patches/Freeplay/TaskAddButtonPatches.cs
@@ -22,15 +22,4 @@ internal static class TaskAddButtonPatches
 
         return true;
     }
-
-    [HarmonyPostfix]
-    [HarmonyPatch(nameof(TaskAddButton.Role), MethodType.Setter)]
-    public static void RoleGetterPatch(TaskAddButton __instance)
-    {
-        if (__instance.role is ICustomRole { Team: ModdedRoleTeams.Custom } customRole)
-        {
-            __instance.FileImage.color = customRole.IntroConfiguration?.IntroTeamColor ?? Color.gray;
-        }
-        __instance.RolloverHandler.OutColor = __instance.FileImage.color;
-    }
 }


### PR DESCRIPTION
It's a simple pr, just allows you to have colors for mod developers to at least color-code modifiers, like how seen here, Alliance modifiers are nearly pure white, Universal modifiers are a light gray, and then Neutral is gray, Crewmate is blue, Impostor is red.
<img width="1284" height="1079" alt="image" src="https://github.com/user-attachments/assets/07b0ca4e-2245-4bb2-9e2d-273aa68bbfeb" />
