### PR TITLE
Invoke RoundStartEvent when starting freeplay

### DIFF
--- a/MiraAPI/Patches/Events/FreeplayRoundStartPatch.cs
+++ b/MiraAPI/Patches/Events/FreeplayRoundStartPatch.cs
@@ -1,0 +1,17 @@
+﻿using HarmonyLib;
+using MiraAPI.Events;
+using MiraAPI.Events.Vanilla.Gameplay;
+
+namespace MiraAPI.Patches.Events;
+
+[HarmonyPatch(typeof(TutorialManager._RunTutorial_d__3), nameof(TutorialManager._RunTutorial_d__3.MoveNext))]
+public static class FreeplayRoundStartPatch
+{
+    public static void Postfix(TutorialManager._RunTutorial_d__3 __instance, ref bool __result)
+    {
+        if (!__result)
+        {
+            MiraEventManager.InvokeEvent(new RoundStartEvent(true));
+        }
+    }
+}


### PR DESCRIPTION
This event runs either when the intro cutscene ends or after someone is ejected but never when freeplay starts, so i added it