### PR TITLE
Fix DefaultKeybind name + Remove Keybind Requirement

### DIFF
--- a/MiraAPI.Example/Buttons/Freezer/FreezeButton.cs
+++ b/MiraAPI.Example/Buttons/Freezer/FreezeButton.cs
@@ -20,7 +20,7 @@ public class FreezeButton : CustomActionButton<PlayerControl>
     public override int MaxUses => (int)OptionGroupSingleton<FreezerRoleSettings>.Instance.FreezeUses;
 
     public override LoadableAsset<Sprite> Sprite => ExampleAssets.ExampleButton;
-    public override KeyboardKeyCode Defaultkeybind => KeyboardKeyCode.T;
+    public override KeyboardKeyCode DefaultKeybind => KeyboardKeyCode.T;
     public override ModifierKey Modifier1 => ModifierKey.Control;
 
     protected override void OnClick()

--- a/MiraAPI.Example/Buttons/MeetingButton.cs
+++ b/MiraAPI.Example/Buttons/MeetingButton.cs
@@ -16,7 +16,7 @@ public class MeetingButton : CustomActionButton
     public override int MaxUses => 3;
 
     public override LoadableAsset<Sprite> Sprite => ExampleAssets.ExampleButton;
-    public override KeyboardKeyCode Defaultkeybind => KeyboardKeyCode.P;
+    public override KeyboardKeyCode DefaultKeybind => KeyboardKeyCode.P;
     public override ModifierKey Modifier1 => ModifierKey.Control;
     public override ModifierKey Modifier2 => ModifierKey.Shift;
 

--- a/MiraAPI.Example/Buttons/NeutralKillerButton.cs
+++ b/MiraAPI.Example/Buttons/NeutralKillerButton.cs
@@ -13,7 +13,7 @@ public class NeutralKillerButton : CustomActionButton
     public override string Name => "Win Game";
     public override float Cooldown => 0f;
     public override LoadableAsset<Sprite> Sprite => ExampleAssets.ExampleButton;
-    public override KeyboardKeyCode Defaultkeybind => KeyboardKeyCode.K;
+    public override KeyboardKeyCode DefaultKeybind => KeyboardKeyCode.K;
     protected override void OnClick()
     {
         CustomGameOver.Trigger<NeutralKillerGameOver>([PlayerControl.LocalPlayer.Data]);

--- a/MiraAPI.Example/Buttons/Teleporter/TeleportButton.cs
+++ b/MiraAPI.Example/Buttons/Teleporter/TeleportButton.cs
@@ -22,7 +22,7 @@ public class TeleportButton : CustomActionButton
     public override LoadableAsset<Sprite> Sprite => ExampleAssets.TeleportButton;
     public override Color TextOutlineColor => new Color32(221, 176, 152, 255);
     public static bool IsZoom { get; private set; }
-    public override KeyboardKeyCode Defaultkeybind => KeyboardKeyCode.M;
+    public override KeyboardKeyCode DefaultKeybind => KeyboardKeyCode.M;
     public override bool Enabled(RoleBehaviour? role)
     {
         return role is TeleporterRole;

--- a/MiraAPI/Hud/CustomActionButton.cs
+++ b/MiraAPI/Hud/CustomActionButton.cs
@@ -56,7 +56,7 @@ public abstract class CustomActionButton
     /// <summary>
     /// Gets or sets the current key binding for this button.
     /// </summary>
-    public abstract KeyboardKeyCode Defaultkeybind { get; }
+    public virtual KeyboardKeyCode DefaultKeybind { get; } = KeyboardKeyCode.None;
 
     /// <summary>
     /// The first optional modifier key (e.g., Control, Shift, Alt) that must be held with the main key to activate the button.

--- a/MiraAPI/PluginLoading/MiraPluginManager.cs
+++ b/MiraAPI/PluginLoading/MiraPluginManager.cs
@@ -18,6 +18,7 @@ using MiraAPI.Roles;
 using MiraAPI.Utilities;
 using Reactor.Networking;
 using Reactor.Utilities;
+using Rewired;
 using UnityEngine;
 
 namespace MiraAPI.PluginLoading;
@@ -137,9 +138,13 @@ public sealed class MiraPluginManager
 
             foreach (var button in CustomButtonManager.Buttons)
             {
-                KeybindManager.Register($"{button.Name}_Keybind", $"Keybind for {button.Name}", button.Defaultkeybind, button.ClickHandler, modifier1: button.Modifier1, modifier2: button.Modifier2, modifier3: button.Modifier3);
+                if (button.DefaultKeybind is KeyboardKeyCode.None)
+                {
+                    continue;
+                }
+                KeybindManager.Register($"{button.Name}_Keybind", $"Keybind for {button.Name}", button.DefaultKeybind, button.ClickHandler, modifier1: button.Modifier1, modifier2: button.Modifier2, modifier3: button.Modifier3);
 
-                Logger<MiraApiPlugin>.Info($"Registered keybind for button '{button.GetType().Name}' with default key {button.Defaultkeybind}.");
+                Logger<MiraApiPlugin>.Info($"Registered keybind for button '{button.GetType().Name}' with default key {button.DefaultKeybind}.");
             }
         };
     }


### PR DESCRIPTION
By default, buttons will use no keybind, and will not add a new keybind option in doing so.