### PR TITLE
Fix null keybind errors

### DIFF
--- a/MiraAPI/Hud/CustomActionButton.cs
+++ b/MiraAPI/Hud/CustomActionButton.cs
@@ -210,7 +210,7 @@ public abstract class CustomActionButton
             }
         }));
 
-        if (DefaultKeybind != KeyboardKeyCode.None)
+        if (DefaultKeybind != null && DefaultKeybind != KeyboardKeyCode.None)
         {
             KeybindEntry = KeybindManager.GetEntries().First(x => x.Id == $"{Name}_Keybind");
             KeybindIcon =


### PR DESCRIPTION
Caused by keybind icons parsing a null keybind as a real keybind