### PR TITLE
Add Before and After Vote Events

### DIFF
--- a/MiraAPI/Events/Vanilla/Meeting/Voting/AfterVoteEvent.cs
+++ b/MiraAPI/Events/Vanilla/Meeting/Voting/AfterVoteEvent.cs
@@ -1,0 +1,30 @@
+﻿using MiraAPI.Voting;
+
+namespace MiraAPI.Events.Vanilla.Meeting.Voting;
+
+/// <summary>
+/// Event that is invoked after the local player successfully votes a player or skips. This event is not cancelable.
+/// </summary>
+public class AfterVoteEvent : MiraEvent
+{
+    /// <summary>
+    /// Gets the instance of the voter's vote data.
+    /// </summary>
+    public PlayerVoteArea VoteArea { get; }
+
+    /// <summary>
+    /// Gets the player who voted.
+    /// </summary>
+    public PlayerControl Player { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AfterVoteEvent"/> class.
+    /// </summary>
+    /// <param name="playerVoteArea">The player vote area that was voted on.</param>
+    /// <param name="voter">The player who voted.</param>
+    public AfterVoteEvent(PlayerVoteArea playerVoteArea, PlayerControl voter)
+    {
+        VoteArea = playerVoteArea;
+        Player = voter;
+    }
+}

--- a/MiraAPI/Events/Vanilla/Meeting/Voting/BeforeVoteEvent.cs
+++ b/MiraAPI/Events/Vanilla/Meeting/Voting/BeforeVoteEvent.cs
@@ -1,0 +1,30 @@
+﻿using MiraAPI.Voting;
+
+namespace MiraAPI.Events.Vanilla.Meeting.Voting;
+
+/// <summary>
+/// Event that is invoked before the local player confirms a vote on a player or when skipping. This event is cancelable.
+/// </summary>
+public class BeforeVoteEvent : MiraCancelableEvent
+{
+    /// <summary>
+    /// Gets the instance of the voter's vote data.
+    /// </summary>
+    public PlayerVoteArea VoteArea { get; }
+
+    /// <summary>
+    /// Gets the player who voted.
+    /// </summary>
+    public PlayerControl Player { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BeforeVoteEvent"/> class.
+    /// </summary>
+    /// <param name="playerVoteArea">The player vote area that was voted on.</param>
+    /// <param name="voter">The player who voted.</param>
+    public BeforeVoteEvent(PlayerVoteArea playerVoteArea, PlayerControl voter)
+    {
+        VoteArea = playerVoteArea;
+        Player = voter;
+    }
+}

--- a/MiraAPI/Patches/Voting/MeetingHudPatches.cs
+++ b/MiraAPI/Patches/Voting/MeetingHudPatches.cs
@@ -15,6 +15,24 @@ namespace MiraAPI.Patches.Voting;
 [SuppressMessage("ReSharper", "InconsistentNaming", Justification = "Harmony Convention")]
 internal static class MeetingHudPatches
 {
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(PlayerVoteArea), nameof(PlayerVoteArea.VoteForMe))]
+    public static bool VotePatch(PlayerVoteArea __instance)
+    {
+        var beforeVoteEvent = new BeforeVoteEvent(__instance, PlayerControl.LocalPlayer);
+        MiraEventManager.InvokeEvent(beforeVoteEvent);
+
+        if (beforeVoteEvent.IsCancelled)
+        {
+            return false;
+        }
+
+        var afterVoteEvent = new AfterVoteEvent(__instance, PlayerControl.LocalPlayer);
+        MiraEventManager.InvokeEvent(afterVoteEvent);
+
+        return true;
+    }
+
     [HarmonyPostfix]
     [HarmonyPatch(nameof(MeetingHud.Start))]
     public static void MeetingHudStartPatch(MeetingHud __instance)


### PR DESCRIPTION
Useful for local checks before a vote is placed (like with TOU Mira Prosecutor)
This also allows checking for when the player skips or when they click on any button with a specific target id