### PR TITLE
Add extensible Achievement API

### DIFF
--- a/MiraAPI.Example/Achievements/AchievementCommands.cs
+++ b/MiraAPI.Example/Achievements/AchievementCommands.cs
@@ -1,0 +1,72 @@
+using System.Globalization;
+using HarmonyLib;
+using MiraAPI.Achievements;
+
+namespace MiraAPI.Example.Achievements;
+
+[HarmonyPatch]
+public static class AchievementCommands
+{
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(ChatController), nameof(ChatController.SendChat))]
+    private static bool SendChatPrefix(ChatController __instance)
+    {
+        var text = __instance.freeChatField.textArea.text.Trim();
+        if (!text.StartsWith("/achievement", true, CultureInfo.InvariantCulture))
+        {
+            return true;
+        }
+
+        var parts = text.Split(' ');
+        if (parts.Length < 2)
+        {
+            __instance.AddChat(PlayerControl.LocalPlayer, "Usage: /achievement <id>  |  /achievement unlock <id>");
+            __instance.freeChatField.textArea.Clear();
+            return false;
+        }
+
+        if (parts[1].Equals("unlock", System.StringComparison.OrdinalIgnoreCase))
+        {
+            if (parts.Length < 3)
+            {
+                __instance.AddChat(PlayerControl.LocalPlayer, "Usage: /achievement unlock <id>");
+                __instance.freeChatField.textArea.Clear();
+                return false;
+            }
+
+            var unlockId = parts[2];
+            if (!MiraAPI.Achievements.AchievementManager.TryGetAchievement(unlockId, out var unlockAch))
+            {
+                __instance.AddChat(PlayerControl.LocalPlayer, $"Achievement '{unlockId}' not found.");
+                __instance.freeChatField.textArea.Clear();
+                return false;
+            }
+
+            unlockAch.SetProgress(PlayerControl.LocalPlayer, unlockAch.Goal);
+            __instance.AddChat(PlayerControl.LocalPlayer, $"Force unlocked: [{unlockAch.Title}]");
+            __instance.freeChatField.textArea.Clear();
+            return false;
+        }
+
+        var achievementId = parts[1];
+        if (!MiraAPI.Achievements.AchievementManager.TryGetAchievement(achievementId, out var achievement))
+        {
+            __instance.AddChat(PlayerControl.LocalPlayer, $"Achievement '{achievementId}' not found.");
+            __instance.freeChatField.textArea.Clear();
+            return false;
+        }
+
+        if (!achievement.IsUnlocked(PlayerControl.LocalPlayer))
+        {
+            __instance.AddChat(PlayerControl.LocalPlayer, $"You haven't unlocked '{achievement.Title}' yet. Use /achievement unlock {achievementId}");
+            __instance.freeChatField.textArea.Clear();
+            return false;
+        }
+
+        MiraAPI.Achievements.AchievementManager.SetEquippedTitle(PlayerControl.LocalPlayer, achievementId);
+        TitleSyncRpc.Send(PlayerControl.LocalPlayer.PlayerId, achievementId);
+        __instance.AddChat(PlayerControl.LocalPlayer, $"Title equipped: [{achievement.Title}]");
+        __instance.freeChatField.textArea.Clear();
+        return false;
+    }
+}

--- a/MiraAPI.Example/Achievements/AchievementTitleComponent.cs
+++ b/MiraAPI.Example/Achievements/AchievementTitleComponent.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Linq;
+using Il2CppInterop.Runtime.Injection;
+using Reactor.Utilities.Attributes;
+using TMPro;
+using UnityEngine;
+
+namespace MiraAPI.Example.Achievements;
+
+[RegisterInIl2Cpp]
+public class AchievementTitleComponent(IntPtr cppPtr) : MonoBehaviour(cppPtr)
+{
+    private TextMeshPro? _titleText;
+    private PlayerControl? _player;
+    private PoolablePlayer? _poolablePlayer;
+    private string? _lastTitleId;
+
+    static AchievementTitleComponent()
+    {
+        ClassInjector.RegisterTypeInIl2Cpp<AchievementTitleComponent>();
+    }
+
+    private void Awake()
+    {
+        if (!TryGetComponent(out _player))
+        {
+            TryGetComponent(out _poolablePlayer);
+        }
+
+        var origText = _player
+            ? _player.cosmetics.nameText
+            : _poolablePlayer?.cosmetics.nameText;
+
+        if (origText == null)
+        {
+            return;
+        }
+
+        var go = new GameObject("AchievementTitle");
+        go.layer = gameObject.layer;
+        go.transform.SetParent(origText.transform.parent, false);
+
+        _titleText = go.AddComponent<TextMeshPro>();
+        _titleText.fontMaterial = origText.fontMaterial;
+        _titleText.outlineWidth = 0.2f;
+        _titleText.outlineColor = Color.black;
+        _titleText.transform.localPosition = new Vector3(0, _player ? 1.1f : 0.75f, -0.01f);
+        _titleText.fontSize = _player ? 2.5f : 1.8f;
+        _titleText.alignment = TextAlignmentOptions.Center;
+    }
+
+    private void Update()
+    {
+        if (_titleText == null)
+        {
+            return;
+        }
+
+        var playerRef = _player ?? (_poolablePlayer
+            ? PlayerControl.AllPlayerControls.ToArray().FirstOrDefault(p => p.PlayerId == (byte)_poolablePlayer.ColorId)
+            : null);
+
+        if (playerRef == null)
+        {
+            return;
+        }
+
+        var equipped = MiraAPI.Achievements.AchievementManager.GetEquippedTitle(playerRef);
+        var currentId = equipped?.Id;
+
+        if (currentId == _lastTitleId)
+        {
+            return;
+        }
+
+        _lastTitleId = currentId;
+
+        if (equipped != null)
+        {
+            _titleText.text = $"[{equipped.Title}]";
+            _titleText.color = equipped.TitleColor;
+        }
+        else
+        {
+            _titleText.text = string.Empty;
+        }
+    }
+
+    private void OnDestroy()
+    {
+        if (_titleText != null)
+        {
+            Destroy(_titleText.gameObject);
+        }
+    }
+}

--- a/MiraAPI.Example/Achievements/ExampleAchievements.cs
+++ b/MiraAPI.Example/Achievements/ExampleAchievements.cs
@@ -1,0 +1,38 @@
+using System.Linq;
+using MiraAPI.Achievements;
+using MiraAPI.Events;
+using MiraAPI.Events.Vanilla.Gameplay;
+using MiraAPI.Events.Vanilla.Player;
+
+namespace MiraAPI.Example.Achievements;
+
+public static class ExampleAchievements
+{
+    public static readonly MadKillerAchievement MadKiller = new();
+    public static readonly FirstVictoryAchievement FirstWin = new();
+
+    public static void Register()
+    {
+        MiraAPI.Achievements.AchievementManager.RegisterAchievement(MadKiller);
+        MiraAPI.Achievements.AchievementManager.RegisterAchievement(FirstWin);
+
+        MiraEventManager.RegisterEventHandler<AfterMurderEvent>(OnMurder);
+        MiraEventManager.RegisterEventHandler<GameEndEvent>(OnGameEnd);
+    }
+
+    private static void OnMurder(AfterMurderEvent @event)
+    {
+        if (@event.Source.AmOwner)
+        {
+            MiraAPI.Achievements.AchievementManager.AddProgress(@event.Source, MadKiller.Id, 1);
+        }
+    }
+
+    private static void OnGameEnd(GameEndEvent @event)
+    {
+        foreach (var plr in PlayerControl.AllPlayerControls.ToArray().Where(p => !p.Data.IsDead && p.AmOwner))
+        {
+            MiraAPI.Achievements.AchievementManager.AddProgress(plr, FirstWin.Id, 1);
+        }
+    }
+}

--- a/MiraAPI.Example/Achievements/FirstVictoryAchievement.cs
+++ b/MiraAPI.Example/Achievements/FirstVictoryAchievement.cs
@@ -1,0 +1,14 @@
+using MiraAPI.Achievements;
+using UnityEngine;
+
+namespace MiraAPI.Example.Achievements;
+
+public class FirstVictoryAchievement : BaseAchievement
+{
+    public override string Id => "first-win";
+    public override string Title => "First Victory";
+    public override string Description => "Win your first game.";
+    public override AchievementTier Tier => AchievementTier.Common;
+    public override int Goal => 1;
+    public override Color TitleColor => Color.green;
+}

--- a/MiraAPI.Example/Achievements/MadKillerAchievement.cs
+++ b/MiraAPI.Example/Achievements/MadKillerAchievement.cs
@@ -1,0 +1,14 @@
+using MiraAPI.Achievements;
+using UnityEngine;
+
+namespace MiraAPI.Example.Achievements;
+
+public class MadKillerAchievement : BaseAchievement
+{
+    public override string Id => "mad-killer";
+    public override string Title => "Mad Killer";
+    public override string Description => "Kill 5 players in a single game.";
+    public override AchievementTier Tier => AchievementTier.Rare;
+    public override int Goal => 5;
+    public override Color TitleColor => Color.red;
+}

--- a/MiraAPI.Example/Achievements/TitlePatch.cs
+++ b/MiraAPI.Example/Achievements/TitlePatch.cs
@@ -1,0 +1,12 @@
+using HarmonyLib;
+
+namespace MiraAPI.Example.Achievements;
+
+[HarmonyPatch(typeof(PlayerControl), nameof(PlayerControl.Start))]
+public static class TitlePatch
+{
+    public static void Postfix(PlayerControl __instance)
+    {
+        __instance.gameObject.AddComponent<AchievementTitleComponent>();
+    }
+}

--- a/MiraAPI.Example/Achievements/TitleSyncRpc.cs
+++ b/MiraAPI.Example/Achievements/TitleSyncRpc.cs
@@ -1,0 +1,46 @@
+using Hazel;
+using Reactor.Networking.Attributes;
+using Reactor.Networking.Rpc;
+
+namespace MiraAPI.Example.Achievements;
+
+[RegisterCustomRpc(100)]
+public class TitleSyncRpc(ExamplePlugin plugin, uint id) : PlayerCustomRpc<ExamplePlugin, TitleSyncRpc.Data>(plugin, id)
+{
+    public class Data
+    {
+        public byte PlayerId { get; set; }
+        public string AchievementId { get; set; } = "-";
+    }
+
+    public override RpcLocalHandling LocalHandling => RpcLocalHandling.After;
+
+    public override void Write(MessageWriter writer, Data data)
+    {
+        writer.Write(data.PlayerId);
+        writer.Write(data.AchievementId);
+    }
+
+    public override Data Read(MessageReader reader)
+    {
+        return new Data
+        {
+            PlayerId = reader.ReadByte(),
+            AchievementId = reader.ReadString(),
+        };
+    }
+
+    public override void Handle(PlayerControl innerNetObject, Data data)
+    {
+        MiraAPI.Achievements.AchievementManager.SetEquippedTitleById(data.PlayerId, data.AchievementId);
+    }
+
+    public static void Send(byte playerId, string? achievementId)
+    {
+        Rpc<TitleSyncRpc>.Instance.SendTo(PlayerControl.LocalPlayer, -1, new Data
+        {
+            PlayerId = playerId,
+            AchievementId = achievementId ?? "-",
+        });
+    }
+}

--- a/MiraAPI.Example/ExamplePlugin.cs
+++ b/MiraAPI.Example/ExamplePlugin.cs
@@ -1,8 +1,10 @@
-﻿using System.Linq;
+using System.Linq;
 using BepInEx;
 using BepInEx.Configuration;
 using BepInEx.Unity.IL2CPP;
 using HarmonyLib;
+using MiraAPI.Achievements;
+using MiraAPI.Example.Achievements;
 using MiraAPI.PluginLoading;
 using Reactor;
 using Reactor.Networking;
@@ -22,6 +24,8 @@ public partial class ExamplePlugin : BasePlugin, IMiraPlugin
     public ConfigFile GetConfigFile() => Config;
     public override void Load()
     {
+        MiraAPI.Achievements.AchievementManager.Initialize(Id);
+        ExampleAchievements.Register();
         ExampleEventHandlers.Initialize();
         Harmony.PatchAll();
     }

--- a/MiraAPI/Achievements/AchievementManager.cs
+++ b/MiraAPI/Achievements/AchievementManager.cs
@@ -5,7 +5,6 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
-using BepInEx;
 using MiraAPI.Events;
 using Reactor.Utilities;
 using UnityEngine;
@@ -17,7 +16,8 @@ namespace MiraAPI.Achievements;
 /// </summary>
 public static class AchievementManager
 {
-    private const string FileExtension = "_Achievement.dat";
+    private const string AchievementDir = "mira_achievement";
+    private const string AchievementFile = "Achievement.dat";
 
     private static readonly Dictionary<string, IAchievement> AllAchievements = [];
     private static readonly Dictionary<byte, AchievementProgressData> PlayerProgress = [];
@@ -33,12 +33,19 @@ public static class AchievementManager
 
     /// <summary>
     /// Initializes the achievement system for a specific mod. Creates/loads the encrypted data file.
+    /// File is stored at: Application.persistentDataPath/mira_achievement/{ModGuid}/Achievement.dat
     /// </summary>
-    /// <param name="modGuid">The mod's unique GUID, used for naming the save file.</param>
+    /// <param name="modGuid">The mod's unique GUID, used for the subfolder name.</param>
     public static void Initialize(string modGuid)
     {
         _currentModGuid = modGuid;
-        _saveFilePath = Path.Combine(Paths.ConfigPath, $"{SanitizeFileName(modGuid)}{FileExtension}");
+        var modDir = Path.Combine(Application.persistentDataPath, AchievementDir, SanitizeFileName(modGuid));
+        if (!Directory.Exists(modDir))
+        {
+            Directory.CreateDirectory(modDir);
+        }
+
+        _saveFilePath = Path.Combine(modDir, AchievementFile);
         LoadProgressFromFile();
     }
 

--- a/MiraAPI/Achievements/AchievementManager.cs
+++ b/MiraAPI/Achievements/AchievementManager.cs
@@ -1,0 +1,321 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using BepInEx;
+using MiraAPI.Events;
+using Reactor.Utilities;
+using UnityEngine;
+
+namespace MiraAPI.Achievements;
+
+/// <summary>
+/// Manages all achievements, progress tracking, title equipping, and data persistence.
+/// </summary>
+public static class AchievementManager
+{
+    private const string FileExtension = "_Achievement.dat";
+
+    private static readonly Dictionary<string, IAchievement> AllAchievements = [];
+    private static readonly Dictionary<byte, AchievementProgressData> PlayerProgress = [];
+    private static readonly Dictionary<byte, string> EquippedTitles = [];
+
+    private static string? _currentModGuid;
+    private static string? _saveFilePath;
+
+    /// <summary>
+    /// Gets a read-only view of all registered achievements.
+    /// </summary>
+    public static IReadOnlyDictionary<string, IAchievement> Achievements => AllAchievements;
+
+    /// <summary>
+    /// Initializes the achievement system for a specific mod. Creates/loads the encrypted data file.
+    /// </summary>
+    /// <param name="modGuid">The mod's unique GUID, used for naming the save file.</param>
+    public static void Initialize(string modGuid)
+    {
+        _currentModGuid = modGuid;
+        _saveFilePath = Path.Combine(Paths.ConfigPath, $"{SanitizeFileName(modGuid)}{FileExtension}");
+        LoadProgressFromFile();
+    }
+
+    /// <summary>
+    /// Registers an achievement with the manager.
+    /// </summary>
+    /// <param name="achievement">The achievement to register.</param>
+    public static void RegisterAchievement(IAchievement achievement)
+    {
+        if (AllAchievements.ContainsKey(achievement.Id))
+        {
+            Error($"Achievement with ID '{achievement.Id}' is already registered.");
+            return;
+        }
+
+        AllAchievements[achievement.Id] = achievement;
+        Info($"Registered achievement: {achievement.Id}");
+    }
+
+    /// <summary>
+    /// Gets an achievement by its ID.
+    /// </summary>
+    public static bool TryGetAchievement(string id, [NotNullWhen(true)] out IAchievement? achievement)
+    {
+        return AllAchievements.TryGetValue(id, out achievement);
+    }
+
+    /// <summary>
+    /// Gets the progress data for a player.
+    /// </summary>
+    public static AchievementProgressData GetProgressData(PlayerControl player)
+    {
+        if (!PlayerProgress.TryGetValue(player.PlayerId, out var data))
+        {
+            data = new AchievementProgressData();
+            PlayerProgress[player.PlayerId] = data;
+        }
+
+        return data;
+    }
+
+    /// <summary>
+    /// Adds progress towards an achievement for a player. Unlocks if goal is reached.
+    /// </summary>
+    /// <returns>True if the achievement was just unlocked.</returns>
+    public static bool AddProgress(PlayerControl player, string achievementId, int amount = 1)
+    {
+        if (!TryGetAchievement(achievementId, out var achievement))
+        {
+            Error($"Achievement '{achievementId}' not found.");
+            return false;
+        }
+
+        var wasUnlocked = achievement.IsUnlocked(player);
+        if (wasUnlocked && !achievement.CanEarnMultiple)
+        {
+            return false;
+        }
+
+        var current = achievement.GetProgress(player);
+        var updated = Mathf.Min(current + amount, achievement.Goal);
+        achievement.SetProgress(player, updated);
+
+        SaveProgressToFile();
+
+        if (!wasUnlocked && updated >= achievement.Goal)
+        {
+            achievement.OnUnlocked(player);
+            MiraEventManager.InvokeEvent(new AchievementUnlockedEvent(player, achievement));
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Gets the equipped title achievement ID for a player.
+    /// </summary>
+    public static string? GetEquippedTitleId(PlayerControl player)
+    {
+        return EquippedTitles.TryGetValue(player.PlayerId, out var titleId) ? titleId : null;
+    }
+
+    /// <summary>
+    /// Gets the equipped title achievement for a player.
+    /// </summary>
+    public static IAchievement? GetEquippedTitle(PlayerControl player)
+    {
+        var titleId = GetEquippedTitleId(player);
+        if (titleId != null && TryGetAchievement(titleId, out var ach) && ach.IsUnlocked(player))
+        {
+            return ach;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Sets the equipped title for a player. This only manages local state.
+    /// Use an RPC to sync across the network if needed.
+    /// </summary>
+    public static void SetEquippedTitle(PlayerControl player, string? achievementId)
+    {
+        if (achievementId == null)
+        {
+            EquippedTitles.Remove(player.PlayerId);
+            SaveProgressToFile();
+            return;
+        }
+
+        if (!TryGetAchievement(achievementId, out var achievement))
+        {
+            Error($"Achievement '{achievementId}' not found.");
+            return;
+        }
+
+        if (!achievement.IsUnlocked(player))
+        {
+            Error($"Achievement '{achievementId}' is not unlocked for player {player.PlayerId}.");
+            return;
+        }
+
+        EquippedTitles[player.PlayerId] = achievementId;
+        SaveProgressToFile();
+    }
+
+    /// <summary>
+    /// Directly sets the equipped title by player ID. Does not validate or save.
+    /// Useful for applying network-synced title data.
+    /// </summary>
+    public static void SetEquippedTitleById(byte playerId, string? achievementId)
+    {
+        if (achievementId == null || achievementId == "-")
+        {
+            EquippedTitles.Remove(playerId);
+        }
+        else
+        {
+            EquippedTitles[playerId] = achievementId;
+        }
+    }
+
+    internal static void ClearAllProgress()
+    {
+        PlayerProgress.Clear();
+        EquippedTitles.Clear();
+    }
+
+    private static string SanitizeFileName(string name)
+    {
+        var invalid = Path.GetInvalidFileNameChars();
+        var sb = new StringBuilder(name.Length);
+        foreach (var c in name)
+        {
+            if (Array.IndexOf(invalid, c) < 0)
+            {
+                sb.Append(c);
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    private static void SaveProgressToFile()
+    {
+        if (string.IsNullOrEmpty(_saveFilePath))
+        {
+            return;
+        }
+
+        try
+        {
+            var saveData = new AchievementSaveData
+            {
+                Progress = PlayerProgress.ToDictionary(
+                    kvp => kvp.Key,
+                    kvp => kvp.Value.ToDictionary()),
+                Titles = EquippedTitles.ToDictionary(
+                    kvp => kvp.Key,
+                    kvp => kvp.Value),
+            };
+
+            var json = JsonSerializer.Serialize(saveData);
+            var encrypted = Encrypt(json);
+            File.WriteAllText(_saveFilePath, encrypted);
+        }
+        catch (Exception e)
+        {
+            Error($"Failed to save achievement data: {e.Message}");
+        }
+    }
+
+    private static void LoadProgressFromFile()
+    {
+        if (string.IsNullOrEmpty(_saveFilePath) || !File.Exists(_saveFilePath))
+        {
+            return;
+        }
+
+        try
+        {
+            var encrypted = File.ReadAllText(_saveFilePath);
+            var json = Decrypt(encrypted);
+            var saveData = JsonSerializer.Deserialize<AchievementSaveData>(json);
+
+            if (saveData == null)
+            {
+                return;
+            }
+
+            PlayerProgress.Clear();
+            foreach (var kvp in saveData.Progress)
+            {
+                var progressData = new AchievementProgressData();
+                progressData.LoadFromDictionary(kvp.Value);
+                PlayerProgress[kvp.Key] = progressData;
+            }
+
+            EquippedTitles.Clear();
+            foreach (var kvp in saveData.Titles)
+            {
+                EquippedTitles[kvp.Key] = kvp.Value;
+            }
+        }
+        catch (Exception e)
+        {
+            Error($"Failed to load achievement data: {e.Message}");
+        }
+    }
+
+    private static string Encrypt(string plainText)
+    {
+        var key = ComputeKey();
+        var result = new StringBuilder();
+        for (var i = 0; i < plainText.Length; i++)
+        {
+            result.Append((char)(plainText[i] ^ key[i % key.Length]));
+        }
+
+        return Convert.ToBase64String(Encoding.UTF8.GetBytes(result.ToString()));
+    }
+
+    private static string Decrypt(string cipherBase64)
+    {
+        var cipherText = Encoding.UTF8.GetString(Convert.FromBase64String(cipherBase64));
+        var key = ComputeKey();
+        var result = new StringBuilder();
+        for (var i = 0; i < cipherText.Length; i++)
+        {
+            result.Append((char)(cipherText[i] ^ key[i % key.Length]));
+        }
+
+        return result.ToString();
+    }
+
+    private static string ComputeKey()
+    {
+        var guid = _currentModGuid ?? "MiraAPI_Achievement";
+        var hash = 0;
+        foreach (var c in guid)
+        {
+            hash = ((hash << 5) + hash) ^ c;
+        }
+
+        var key = new StringBuilder();
+        for (var i = 0; i < 16; i++)
+        {
+            key.Append((char)('A' + (Math.Abs(hash + i * 7) % 26)));
+        }
+
+        return key.ToString();
+    }
+
+    [Serializable]
+    internal class AchievementSaveData
+    {
+        public Dictionary<byte, Dictionary<string, int>> Progress { get; set; } = [];
+        public Dictionary<byte, string> Titles { get; set; } = [];
+    }
+}

--- a/MiraAPI/Achievements/AchievementProgressData.cs
+++ b/MiraAPI/Achievements/AchievementProgressData.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+
+namespace MiraAPI.Achievements;
+
+/// <summary>
+/// Stores per-achievement progress for a single player.
+/// </summary>
+public class AchievementProgressData
+{
+    private readonly Dictionary<string, int> _progress = [];
+
+    /// <summary>
+    /// Gets the progress for a specific achievement.
+    /// </summary>
+    /// <param name="achievementId">The achievement ID.</param>
+    /// <returns>Current progress value.</returns>
+    public int GetProgress(string achievementId)
+    {
+        return _progress.TryGetValue(achievementId, out var value) ? value : 0;
+    }
+
+    /// <summary>
+    /// Sets the progress for a specific achievement.
+    /// </summary>
+    /// <param name="achievementId">The achievement ID.</param>
+    /// <param name="value">The new progress value.</param>
+    public void SetProgress(string achievementId, int value)
+    {
+        _progress[achievementId] = value;
+    }
+
+    internal Dictionary<string, int> ToDictionary()
+    {
+        return new Dictionary<string, int>(_progress);
+    }
+
+    internal void LoadFromDictionary(Dictionary<string, int> dict)
+    {
+        _progress.Clear();
+        foreach (var kvp in dict)
+        {
+            _progress[kvp.Key] = kvp.Value;
+        }
+    }
+}

--- a/MiraAPI/Achievements/AchievementTier.cs
+++ b/MiraAPI/Achievements/AchievementTier.cs
@@ -1,0 +1,32 @@
+namespace MiraAPI.Achievements;
+
+/// <summary>
+/// Defines the rarity tier of an achievement.
+/// </summary>
+public enum AchievementTier
+{
+    /// <summary>
+    /// Common achievement, easy to earn.
+    /// </summary>
+    Common,
+
+    /// <summary>
+    /// Uncommon achievement.
+    /// </summary>
+    Uncommon,
+
+    /// <summary>
+    /// Rare achievement.
+    /// </summary>
+    Rare,
+
+    /// <summary>
+    /// Epic achievement.
+    /// </summary>
+    Epic,
+
+    /// <summary>
+    /// Legendary achievement, very hard to earn.
+    /// </summary>
+    Legendary,
+}

--- a/MiraAPI/Achievements/AchievementUnlockedEvent.cs
+++ b/MiraAPI/Achievements/AchievementUnlockedEvent.cs
@@ -1,0 +1,30 @@
+using MiraAPI.Events;
+
+namespace MiraAPI.Achievements;
+
+/// <summary>
+/// Event invoked when a player unlocks an achievement for the first time.
+/// </summary>
+public class AchievementUnlockedEvent : MiraEvent
+{
+    /// <summary>
+    /// Gets the player who unlocked the achievement.
+    /// </summary>
+    public PlayerControl Player { get; }
+
+    /// <summary>
+    /// Gets the achievement that was unlocked.
+    /// </summary>
+    public IAchievement Achievement { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AchievementUnlockedEvent"/> class.
+    /// </summary>
+    /// <param name="player">The player who unlocked it.</param>
+    /// <param name="achievement">The unlocked achievement.</param>
+    public AchievementUnlockedEvent(PlayerControl player, IAchievement achievement)
+    {
+        Player = player;
+        Achievement = achievement;
+    }
+}

--- a/MiraAPI/Achievements/BaseAchievement.cs
+++ b/MiraAPI/Achievements/BaseAchievement.cs
@@ -1,0 +1,58 @@
+using MiraAPI.Achievements;
+using UnityEngine;
+
+namespace MiraAPI.Achievements;
+
+/// <summary>
+/// Abstract base class for achievements. Override members to define a custom achievement.
+/// </summary>
+public abstract class BaseAchievement : IAchievement
+{
+    /// <inheritdoc />
+    public abstract string Id { get; }
+
+    /// <inheritdoc />
+    public abstract string Title { get; }
+
+    /// <inheritdoc />
+    public abstract string Description { get; }
+
+    /// <inheritdoc />
+    public abstract AchievementTier Tier { get; }
+
+    /// <inheritdoc />
+    public virtual bool IsHidden => false;
+
+    /// <inheritdoc />
+    public virtual bool CanEarnMultiple => false;
+
+    /// <inheritdoc />
+    public virtual int Goal => 1;
+
+    /// <inheritdoc />
+    public virtual Color TitleColor => Color.white;
+
+    /// <inheritdoc />
+    public int GetProgress(PlayerControl player)
+    {
+        return AchievementManager.GetProgressData(player).GetProgress(Id);
+    }
+
+    /// <inheritdoc />
+    public void SetProgress(PlayerControl player, int value)
+    {
+        AchievementManager.GetProgressData(player).SetProgress(Id, Mathf.Clamp(value, 0, Goal));
+    }
+
+    /// <inheritdoc />
+    public bool IsUnlocked(PlayerControl player)
+    {
+        return GetProgress(player) >= Goal;
+    }
+
+    /// <inheritdoc />
+    public virtual bool CheckCondition(PlayerControl player) => false;
+
+    /// <inheritdoc />
+    public virtual void OnUnlocked(PlayerControl player) { }
+}

--- a/MiraAPI/Achievements/IAchievement.cs
+++ b/MiraAPI/Achievements/IAchievement.cs
@@ -1,0 +1,84 @@
+using UnityEngine;
+
+namespace MiraAPI.Achievements;
+
+/// <summary>
+/// Interface for custom achievements. Implement this to define a new achievement.
+/// </summary>
+public interface IAchievement
+{
+    /// <summary>
+    /// Gets the unique identifier for this achievement.
+    /// </summary>
+    string Id { get; }
+
+    /// <summary>
+    /// Gets the display title shown as name prefix, e.g. "Mad Killer".
+    /// </summary>
+    string Title { get; }
+
+    /// <summary>
+    /// Gets the description of how to earn this achievement.
+    /// </summary>
+    string Description { get; }
+
+    /// <summary>
+    /// Gets the tier/rarity of this achievement.
+    /// </summary>
+    AchievementTier Tier { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether this achievement is hidden until unlocked.
+    /// </summary>
+    bool IsHidden => false;
+
+    /// <summary>
+    /// Gets a value indicating whether this achievement can be earned multiple times (cumulative stat).
+    /// </summary>
+    bool CanEarnMultiple => false;
+
+    /// <summary>
+    /// Gets the target progress value required to unlock. Default is 1 (single completion).
+    /// </summary>
+    int Goal => 1;
+
+    /// <summary>
+    /// Gets the color of the title when displayed on the player name.
+    /// </summary>
+    Color TitleColor => Color.white;
+
+    /// <summary>
+    /// Gets the current progress for a player towards this achievement.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    /// <returns>Current progress value.</returns>
+    int GetProgress(PlayerControl player);
+
+    /// <summary>
+    /// Sets the progress for a player towards this achievement.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    /// <param name="value">The new progress value.</param>
+    void SetProgress(PlayerControl player, int value);
+
+    /// <summary>
+    /// Checks if this achievement is unlocked for a player.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    /// <returns>True if unlocked.</returns>
+    bool IsUnlocked(PlayerControl player);
+
+    /// <summary>
+    /// Evaluates whether the condition to unlock this achievement has been met.
+    /// Override in subclasses for automatic condition checking.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    /// <returns>True if the condition is met.</returns>
+    bool CheckCondition(PlayerControl player) => false;
+
+    /// <summary>
+    /// Called when this achievement is first unlocked by a player.
+    /// </summary>
+    /// <param name="player">The player who unlocked it.</param>
+    void OnUnlocked(PlayerControl player) { }
+}


### PR DESCRIPTION
 ### Overview
  Add an extensible achievement API to MiraAPI. The API provides only data logic
  — no UI, no networking. The Example project demonstrates how to build title
  display, RPC sync, and chat commands on top of it.

  ### API (`MiraAPI/Achievements/`)
  - `IAchievement` — interface for defining custom achievements
  - `BaseAchievement` — abstract base with built-in progress tracking
  - `AchievementManager` — registry, progress, titles, encrypted file persistence
  - `AchievementTier` — rarity enum (Common → Legendary)
  - `AchievementUnlockedEvent` — MiraEvent fired on first unlock

  ### Persistence
  - Stored alongside existing presets:
    `Application.persistentDataPath/mira_achievement/{ModGuid}/Achievement.dat`
  - Same layout as `mira_presets/` — one folder per mod GUID
  - XOR encryption with a key derived from the mod GUID

  ### Example (`MiraAPI.Example/Achievements/`)
  - `MadKillerAchievement` / `FirstVictoryAchievement` — sample achievements
  - `/achievement <id>` — equip an unlocked title in chat
  - `/achievement unlock <id>` — force-unlock for testing
  - `AchievementTitleComponent` — shows `[Title]` above player name
  - `TitleSyncRpc` — syncs equipped title across network

  ### Scope
  This is the minimal foundation. Extension ideas that consumers can build on top:
  - Achievement UI — browse all achievements, view progress bars, equip titles
  - Cloud stats — upload progress to a server for leaderboards or cross-device sync
  - Seasonal achievements — time-limited achievements that auto-expire

  ### Notes
  Extensive XML doc comments are included on all public members to fully
  demonstrate the API surface. Some phrasing may be slightly off — I'm not a
  native English speaker and relied on translation tools for parts of the docs.