### PR TITLE
Fix duplicate and missing role assignment and duplicate role option rows

### DIFF
--- a/MiraAPI/Patches/Options/RoleSettingMenuPatches.cs
+++ b/MiraAPI/Patches/Options/RoleSettingMenuPatches.cs
@@ -31,6 +31,14 @@ public static class RoleSettingMenuPatches
     private static RoleBehaviour? CurrentRole { get; set; }
     private static List<IModdedOption>? CurrentRoleOptions { get; set; }
 
+    private static readonly Dictionary<int, List<GameObject>> TrackedObjectsByMod = [];
+    private static List<GameObject>? _currentTracked;
+
+    private static void Track(GameObject go)
+    {
+        _currentTracked?.Add(go);
+    }
+
     [HarmonyPostfix]
     [HarmonyPatch(nameof(RolesSettingsMenu.OnEnable))]
     public static void OpenPatch(RolesSettingsMenu __instance)
@@ -42,6 +50,25 @@ public static class RoleSettingMenuPatches
     {
         CurrentRole = null;
         CurrentRoleOptions = null;
+
+        var modIdx = MenuState.Instance.CurrentModIdx;
+        if (TrackedObjectsByMod.TryGetValue(modIdx, out var previouslyTracked))
+        {
+            foreach (var go in previouslyTracked)
+            {
+                if (go != null)
+                {
+                    Object.Destroy(go);
+                }
+            }
+
+            previouslyTracked.Clear();
+            _currentTracked = previouslyTracked;
+        }
+        else
+        {
+            _currentTracked = TrackedObjectsByMod[modIdx] = [];
+        }
 
         roleMenu.QuotaTabSelectables.Clear();
         roleMenu.roleChances.Clear();
@@ -121,6 +148,7 @@ public static class RoleSettingMenuPatches
                     Vector3.zero,
                     Quaternion.identity,
                     roleMenu.RoleChancesSettings.transform);
+                Track(categoryHeaderEditRole.gameObject);
                 categoryHeaderEditRole.SetHeader(StringNames.CrewmateRolesHeader, 20);
                 categoryHeaderEditRole.transform.localPosition = new Vector3(4.986f, num, -2f);
                 num -= 0.522f;
@@ -137,6 +165,7 @@ public static class RoleSettingMenuPatches
                     Vector3.zero,
                     Quaternion.identity,
                     roleMenu.RoleChancesSettings.transform);
+                Track(categoryHeaderEditRole2.gameObject);
                 categoryHeaderEditRole2.SetHeader(StringNames.ImpostorRolesHeader, 20);
                 categoryHeaderEditRole2.transform.localPosition = new Vector3(4.986f, num, -2f);
                 num -= 0.522f;
@@ -197,6 +226,7 @@ public static class RoleSettingMenuPatches
                             Vector3.zero,
                             Quaternion.identity,
                             roleMenu.RoleChancesSettings.transform);
+                        Track(categoryHeaderMasked.gameObject);
 
                         categoryHeaderMasked.SetHeader(name, 20);
 
@@ -645,6 +675,7 @@ public static class RoleSettingMenuPatches
             Vector3.zero,
             Quaternion.identity,
             __instance.RoleChancesSettings.transform);
+        Track(roleOptionSetting.gameObject);
         roleOptionSetting.transform.localPosition = new Vector3(-0.1f, ScrollerNum, -2f);
 
         roleOptionSetting.SetRole(GameOptionsManager.Instance.CurrentGameOptions.RoleOptions, role, 20);

--- a/MiraAPI/Patches/Roles/LogicRoleSelectionNormalPatch.cs
+++ b/MiraAPI/Patches/Roles/LogicRoleSelectionNormalPatch.cs
@@ -56,7 +56,9 @@ public static class LogicRoleSelectionNormalPatch
             new RoleManager.RoleAssignmentData(
                 role,
                 roleOptions.GetNumPerGame(role.Role),
-                roleOptions.GetChancePerGame(role.Role))).ToList();
+                roleOptions.GetChancePerGame(role.Role)))
+            .Where(x => x.Chance < 100)
+            .ToList();
 
         list.Clear();
         foreach (RoleManager.RoleAssignmentData roleAssignmentData3 in list2)
@@ -81,7 +83,9 @@ public static class LogicRoleSelectionNormalPatch
             // Ignored
         }
 
-        while (list.Count < players.Count && list.Count + num < teamMax)
+        list.Clear();
+        var deficit = teamMax - num;
+        for (var i = 0; i < deficit; i++)
         {
             list.Add(defaultRole2);
         }


### PR DESCRIPTION
## Summary
- `LogicRoleSelectionNormalPatch`: the final fallback pass appended to `list` without clearing it first, so it could resend entries from the probability pass alongside the fallback fill on the same `AssignRolesFromList` call. This is also why a team configured with only its plain vanilla role (e.g. only "Impostor", no other impostor role picked) could end up with the role never actually assigned even with enough players. The pass now clears `list` and fills it strictly off the real deficit (`teamMax - num`).
- `RoleSettingMenuPatches.CoQuotaTabPatch`: role option rows are created a few at a time across frames via `CoLoopWithBudget`. If that coroutine gets interrupted mid-way (fast tab switching triggers `StopCoroutine`), whatever it had already instantiated was never tracked or destroyed — just orphaned under `RoleChancesSettings`. The next run then created a fresh set on top, producing two overlapping `RoleOptionSetting` rows (and overlapping count/chance text) for the same role, with the stale one still wired to `OnValueChanged`. Objects created per mod tab are now tracked and explicitly torn down before rebuilding.

## Test plan
- [x] Configure a team with only its base vanilla role (no custom roles) and confirm it's assigned every game
- [x] Rapidly switch between mod tabs / open-close the role settings menu and confirm no duplicate/overlapping role rows appear
- [x] Confirm role counts and chances still save/sync correctly after switching tabs